### PR TITLE
Feature/restrict to localhost

### DIFF
--- a/.changeset/flat-shirts-pay.md
+++ b/.changeset/flat-shirts-pay.md
@@ -1,0 +1,7 @@
+---
+"alexaka1/distroless-dotnet-healthchecks": patch
+---
+
+Restrict health checks to be only valid on loopback addresses.
+
+This limits the attack surface of the app, so that it can't be used to exfiltrate data from the container, by a malicious healthcheck address.

--- a/Distroless.sln
+++ b/Distroless.sln
@@ -8,6 +8,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 	ProjectSection(SolutionItems) = preProject
 		editorconfig = .editorconfig
 		README.md = README.md
+		package.json = package.json
+		pnpm-workspace.yaml = pnpm-workspace.yaml
 	EndProjectSection
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "GitHub", "GitHub", "{98C8D84E-175C-4D2C-9717-8AC13EBAF534}"

--- a/src/Distroless.HealthChecks/Checks/SimpleHealthCheck.cs
+++ b/src/Distroless.HealthChecks/Checks/SimpleHealthCheck.cs
@@ -8,7 +8,8 @@ namespace Distroless.HealthChecks.Checks;
 public partial class SimpleHealthCheck(
     IOptions<HealthCheckOptions> options,
     IHttpClientFactory clientFactory,
-    ILogger<SimpleHealthCheck> logger) : IHealthCheck
+    ILogger<SimpleHealthCheck> logger
+    ) : IHealthCheck
 {
     public const string Name = "SimpleCheck";
 

--- a/src/Distroless.HealthChecks/Dockerfile
+++ b/src/Distroless.HealthChecks/Dockerfile
@@ -17,11 +17,11 @@ ARG BUILD_CONFIGURATION=Release
 ARG TARGETARCH
 RUN dotnet publish "Distroless.HealthChecks.csproj" -c $BUILD_CONFIGURATION -a $TARGETARCH -o /app/publish
 
+FROM scratch AS binary
+COPY --from=publish /app/publish .
+
 FROM base AS final
 WORKDIR /app
 COPY --from=publish /app/publish .
 ENTRYPOINT ["./Distroless.HealthChecks"]
 CMD ["--urls", "http://localhost:8080/healthz"]
-
-FROM scratch AS binary
-COPY --from=publish /app/publish .

--- a/src/Distroless.HealthChecks/Features/Features.cs
+++ b/src/Distroless.HealthChecks/Features/Features.cs
@@ -1,0 +1,7 @@
+namespace Distroless.HealthChecks.Features;
+
+public class Features
+{
+    public const string Key = "Features";
+    public bool AllowUnsafeExternalUris { get; set; }
+}

--- a/src/Distroless.HealthChecks/HealthCheckOptions.cs
+++ b/src/Distroless.HealthChecks/HealthCheckOptions.cs
@@ -1,3 +1,4 @@
+using System.Net;
 using System.Text.Json.Serialization;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
@@ -23,6 +24,9 @@ public partial class PostConfigureHealthCheckOptions(
 )
     : IPostConfigureOptions<HealthCheckOptions>
 {
+    private readonly Lazy<IPAddress[]> _localAddresses = new(() =>
+        [..Dns.GetHostAddresses(Dns.GetHostName()), IPAddress.Loopback, IPAddress.IPv6Loopback]);
+
     public void PostConfigure(string? name, HealthCheckOptions options)
     {
         var f = features.Value;
@@ -37,7 +41,7 @@ public partial class PostConfigureHealthCheckOptions(
         {
             if (!f.AllowUnsafeExternalUris)
             {
-                foreach (var uri in options.Uris.Where(uri => !uri.IsLoopback))
+                foreach (var uri in options.Uris.Where(uri => !IsLoopback(uri)))
                 {
                     throw new NotSupportedException(
                         $"Health checks are only supported on loopback addresses. {uri} is not a loopback address.")
@@ -60,7 +64,7 @@ public partial class PostConfigureHealthCheckOptions(
         {
             if (Uri.TryCreate(uri, UriKind.Absolute, out var uriResult))
             {
-                if (!f.AllowUnsafeExternalUris && !uriResult.IsLoopback)
+                if (!f.AllowUnsafeExternalUris && !IsLoopback(uriResult))
                 {
                     throw new NotSupportedException(
                         $"Health checks are only supported on loopback addresses. {uri} is not a loopback address.")
@@ -81,9 +85,49 @@ public partial class PostConfigureHealthCheckOptions(
         }
     }
 
+    private bool IsLoopback(Uri uri)
+    {
+        try
+        {
+            if (uri.IsLoopback)
+            {
+                return true;
+            }
+
+            // Get the IP addresses of the given hostname
+            var hostAddresses = Dns.GetHostAddresses(uri.Host);
+            LogHostAddress(uri, hostAddresses);
+
+            // Get the IP addresses of the local machine
+            var localAddresses = _localAddresses.Value;
+            LogHostAddress(localAddresses);
+
+            // Check if any of the host's addresses match any of the local addresses
+            return hostAddresses.Any(hostAddr => localAddresses.Any(hostAddr.Equals));
+        }
+        catch (Exception e)
+        {
+            LogUnableToDetermineHostAddress(e, uri);
+        }
+
+        return false;
+    }
+
     [LoggerMessage(Level = LogLevel.Warning, Message = "Invalid uri '{Uri}'", EventName = "InvalidUri")]
     private partial void LogInvalidUri(string uri);
 
     [LoggerMessage(Level = LogLevel.Debug, Message = "Urls: {Urls}", EventName = "Urls")]
     private partial void LogUrls(string? urls);
+
+    [LoggerMessage(Level = LogLevel.Error, Message = "Unable to determine host address of {Uri}",
+        EventName = "UnableToDetermineHostAddress")]
+    private partial void LogUnableToDetermineHostAddress(Exception ex, Uri uri);
+
+    [LoggerMessage(Level = LogLevel.Trace, Message = "Host address of uri {Uri} is {HostAddress}",
+        EventName = "UriHostAddress")]
+    private partial void LogHostAddress(Uri uri, IPAddress[] hostAddress);
+
+    [LoggerMessage(Level = LogLevel.Trace, Message = "Host address of machine is {HostAddress}",
+        EventName = "HostAddress")]
+    private partial void LogHostAddress(IPAddress[] hostAddress);
 }

--- a/src/Distroless.HealthChecks/HealthCheckOptions.cs
+++ b/src/Distroless.HealthChecks/HealthCheckOptions.cs
@@ -31,6 +31,17 @@ public partial class PostConfigureHealthCheckOptions(ILogger<PostConfigureHealth
 
         if (options.Uris.Count != 0)
         {
+            foreach (var uri in options.Uris.Where(uri => !uri.IsLoopback))
+            {
+                throw new NotSupportedException($"Health checks are only supported on loopback addresses. {uri} is not a loopback address.")
+                {
+                    Data =
+                    {
+                        { "Uri", uri },
+                    },
+                };
+            }
+
             // Someone has already configured the Uris.
             // They know what they are doing.
             return;
@@ -41,6 +52,16 @@ public partial class PostConfigureHealthCheckOptions(ILogger<PostConfigureHealth
         {
             if (Uri.TryCreate(uri, UriKind.Absolute, out var uriResult))
             {
+                if (!uriResult.IsLoopback)
+                {
+                    throw new NotSupportedException($"Health checks are only supported on loopback addresses. {uri} is not a loopback address.")
+                    {
+                        Data =
+                        {
+                            { "Uri", uri },
+                        },
+                    };
+                }
                 options.Uris.Add(uriResult);
             }
             else

--- a/src/Distroless.HealthChecks/Program.cs
+++ b/src/Distroless.HealthChecks/Program.cs
@@ -1,5 +1,6 @@
 using Distroless.HealthChecks;
 using Distroless.HealthChecks.Checks;
+using Distroless.HealthChecks.Features;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Configuration.Memory;
 using Microsoft.Extensions.DependencyInjection;
@@ -26,6 +27,9 @@ try
     var config = builder.Configuration;
     builder.Services.AddOptions<HealthCheckOptions>()
         .Bind(config)
+        .ValidateOnStart();
+    builder.Services.AddOptions<Features>()
+        .Bind(config.GetSection(Features.Key))
         .ValidateOnStart();
 
     builder.Logging.ClearProviders();

--- a/test/Distroless.HealthChecks.Test/ParameterTests/UrlsTest.cs
+++ b/test/Distroless.HealthChecks.Test/ParameterTests/UrlsTest.cs
@@ -45,7 +45,7 @@ public class UrlsTest(ITestOutputHelper output) : IAsyncLifetime
                 (string.Join(',', [GetUrl(HealthStatus.Degraded)]), HealthStatus.UnHealthy),
                 (string.Join(',', ["http://127.0.0.1:8080/healthz"]), HealthStatus.Healthy),
                 (string.Join(',', ["http://attacker.com:8080/healthz"]), HealthStatus.Healthy),
-                (string.Join(',', ["https://google.com/"]), HealthStatus.UnHealthy),
+                (string.Join(',', ["https://status.cloud.google.com/"]), HealthStatus.UnHealthy),
             ];
             var data = new TheoryData<string, string, string, string, string, HealthStatus>();
             foreach (string image in images)

--- a/test/Distroless.HealthChecks.Test/ParameterTests/UrlsTest.cs
+++ b/test/Distroless.HealthChecks.Test/ParameterTests/UrlsTest.cs
@@ -61,7 +61,7 @@ public class UrlsTest(ITestOutputHelper output) : IAsyncLifetime
 
                         data.Add(image,
                             tag,
-                            "9.0",
+                            tag[..3],
                             Dockerfile,
                             url.url,
                             url.expected
@@ -151,6 +151,7 @@ public class UrlsTest(ITestOutputHelper output) : IAsyncLifetime
                 strategy => strategy.WithTimeout(TimeSpan.FromSeconds(30)))
             )
             .WithExtraHost("attacker.com", "127.0.0.1")
+            // .WithEnvironment("DOTNET_Logging__LogLevel__Distroless.HealthChecks", "Trace")
             .Build();
     }
 

--- a/test/Distroless.Sample.WebApp/aot.Dockerfile
+++ b/test/Distroless.Sample.WebApp/aot.Dockerfile
@@ -24,7 +24,8 @@ EXPOSE 8080
 EXPOSE 8081
 WORKDIR /healthchecks
 COPY --from=distroless-dotnet-healthchecks:test / .
-HEALTHCHECK --interval=1s --timeout=1s --retries=3 CMD ["/healthchecks/Distroless.HealthChecks", "--urls", "http://localhost:8080/healthz"]
+HEALTHCHECK --interval=1s --timeout=1s --retries=3 \
+   CMD ["/healthchecks/Distroless.HealthChecks", "--urls", "http://localhost:8080/healthz"]
 USER $APP_UID
 WORKDIR /app
 COPY --from=publish --chown=$APP_UID /app/publish .


### PR DESCRIPTION
Restrict health check to loopback addresses. An attacker could compromise the health check by supplying external addresses with query parameters and extract data.

Disable it with `--features:AllowUnsafeExternalUris true`