### PR TITLE
Split tests across runners

### DIFF
--- a/.github/workflows/test-workflow.yml
+++ b/.github/workflows/test-workflow.yml
@@ -19,6 +19,16 @@ on:
         description: "Artifact name to download for healthcheck image"
         type: string
         required: false
+      chunk:
+        description: "Test chunk identifier (e.g., '1/3')"
+        type: string
+        required: false
+        default: 1/1
+      test-ids-artifact:
+        description: "Artifact name containing list of test IDs"
+        type: string
+        required: false
+        default: test-ids
 
 
 permissions: { }
@@ -67,18 +77,44 @@ jobs:
           dotnet-quality: 'preview'
       - name: DotNet tools restore
         run: dotnet tool restore
+      - name: Download test ids
+        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0.0
+        with:
+          name: ${{ inputs.test-ids-artifact }}
+          path: ${{ runner.temp }}
+      - name: Select test ids for chunk
+        run: |
+          chunk="${{ inputs.chunk }}"
+          index="${chunk%%/*}"
+          total="${chunk##*/}"
+          ids_file="${{ runner.temp }}/test-ids.json"
+          count=$(jq '.tests | length' "$ids_file")
+          start=$(( (index-1)*count/total ))
+          end=$(( index*count/total ))
+          jq -r ".tests | map(.id) | .[${start}:${end}][]" "$ids_file" > "${{ runner.temp }}/selected-ids.txt"
       - name: Run tests
-        run: >-
-          dotnet test
-          --configuration Release
-          --
-          --crashdump
-          --hangdump
-          --hangdump-timeout 30m
-          --retry-failed-tests 2
-          --retry-failed-tests-max-tests 5
-          --report-xunit-trx
-          --max-threads 2
+        run: |
+          ids=($(cat "${{ runner.temp }}/selected-ids.txt"))
+          args=()
+          for id in "${ids[@]}"; do
+            args+=("-id" "$id")
+          done
+          if [ "${{ inputs.base-image-type }}" = "alpine" ]; then
+            parallel=""
+          else
+            parallel="--max-parallelism 3"
+          fi
+          dotnet test \
+            --configuration Release \
+            -- \
+            --crashdump \
+            --hangdump \
+            --hangdump-timeout 30m \
+            --retry-failed-tests 2 \
+            --retry-failed-tests-max-tests 5 \
+            --report-xunit-trx \
+            $parallel \
+            "${args[@]}"
         env:
           BASE_IMAGE_TYPE: ${{ inputs.base-image-type }}
           HEALTHCHECK_IMAGE: ${{ inputs.healthcheck_image }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -71,8 +71,47 @@ jobs:
           name: ${{ env.HEALTHCHECK_IMAGE_NAME }}-${{ matrix.target-os }}-${{ matrix.platform }}-${{ matrix.base-image-type }}
           path: ${{ runner.temp }}/image.tar
 
+  list-test-ids:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@ec9f2d5744a09debf3a187a3f4f675c53b671911 # v2.13.0
+        with:
+          disable-sudo: true
+          egress-policy: audit
+      - name: Checkout repository
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          persist-credentials: false
+      - name: Setup Dotnet
+        uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4.3.1
+        with:
+          dotnet-version: |
+            9.0.x
+      - name: Setup Dotnet 10 preview
+        uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4.3.1
+        with:
+          dotnet-version: '10.0.x'
+          dotnet-quality: 'preview'
+      - name: DotNet tools restore
+        run: dotnet tool restore
+      - name: List tests
+        run: |
+          dotnet test test/Distroless.HealthChecks.Test/Distroless.HealthChecks.Test.csproj \
+            --configuration Release \
+            -- \
+            -list full \
+            -list-format json > ${{ runner.temp }}/test-ids.json
+      - name: Upload test ids
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: test-ids
+          path: ${{ runner.temp }}/test-ids.json
+
   test:
-    needs: build-healthcheck
+    needs:
+      - build-healthcheck
+      - list-test-ids
     strategy:
       fail-fast: false
       matrix:
@@ -82,12 +121,29 @@ jobs:
         base-image-type:
           - ubuntu-chiseled
           - alpine
+        chunk:
+          - 1/3
+          - 2/3
+          - 3/3
         include:
           - target-os: linux
           - platform: amd64
             os: ubuntu-latest
           - platform: arm64
             os: ubuntu-24.04-arm
+          - platform: amd64
+            base-image-type: alpine
+            chunk: 1/1
+          - platform: arm64
+            base-image-type: alpine
+            chunk: 1/1
+        exclude:
+          - base-image-type: alpine
+            chunk: 1/3
+          - base-image-type: alpine
+            chunk: 2/3
+          - base-image-type: alpine
+            chunk: 3/3
     permissions:
       contents: read
       pull-requests: write
@@ -97,3 +153,5 @@ jobs:
       healthcheck_image: distroless-dotnet-healthchecks:test
       base-image-type: ${{ matrix.base-image-type }}
       healthcheck_artifact: distroless-dotnet-healthchecks-${{ matrix.target-os }}-${{ matrix.platform }}-${{ matrix.base-image-type }}
+      chunk: ${{ matrix.chunk }}
+      test-ids-artifact: test-ids

--- a/nuget.config
+++ b/nuget.config
@@ -2,8 +2,12 @@
 
 <configuration>
   <packageSources>
-    <!--To inherit the global NuGet package sources remove the <clear/> line below -->
     <clear />
-    <add key="nuget" value="https://api.nuget.org/v3/index.json" />
+    <add key="nuget.org"
+         value="https://api.nuget.org/v3/index.json"
+         protocolVersion="3" />
+    <add key="feedz.io/xunit/xunit"
+         value="https://f.feedz.io/xunit/xunit/nuget/index.json"
+         protocolVersion="3" />
   </packageSources>
 </configuration>

--- a/test/Distroless.HealthChecks.Test/Distroless.HealthChecks.Test.csproj
+++ b/test/Distroless.HealthChecks.Test/Distroless.HealthChecks.Test.csproj
@@ -20,7 +20,7 @@
     <PackageReference Include="Microsoft.Testing.Extensions.HangDump" Version="1.8.3"/>
     <PackageReference Include="Microsoft.Testing.Extensions.Retry" Version="1.8.3"/>
     <PackageReference Include="Testcontainers" Version="4.7.0"/>
-    <PackageReference Include="xunit.v3" Version="3.0.1"/>
+    <PackageReference Include="xunit.v3" Version="3.0.2-pre.18"/>
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary
- list test IDs once and share via artifact
- split Ubuntu tests into three chunks filtered by ID
- run Alpine tests without parallelism limit
- switch test project to xunit.v3 3.0.2-pre.18 via feedz.io and output IDs in JSON for robust chunking

## Testing
- `curl -L https://dot.net/v1/dotnet-install.sh -o dotnet-install.sh && bash dotnet-install.sh -c 10.0 --quality preview --install-dir $HOME/dotnet` *(fails: Failed to locate the latest version in the channel '10.0' with 'preview' quality for 'dotnet-sdk')*
- `dotnet restore Distroless.sln -v minimal` *(fails: The current .NET SDK does not support targeting .NET 10.0)*
- `dotnet test Distroless.sln -c Release` *(fails: The current .NET SDK does not support targeting .NET 10.0)*
- `pnpm check-licenses:dotnet` *(fails: The proxy tunnel request to proxy 'http://proxy:8080/' failed with status code '403' for https://f.feedz.io/xunit/xunit/nuget/index.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b72786453c8330b8694f7fba9742f3