### PR TITLE
Add dotnet build

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -35,7 +35,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        language: [ "csharp", "actions" ]
+        include:
+          - language: actions
+            build-mode: autobuild
+          - language: csharp
+            build-mode: manual
         # CodeQL supports [ $supported-codeql-languages ]
         # Learn more about CodeQL language support at https://aka.ms/codeql-docs/language-support
 
@@ -74,17 +78,17 @@ jobs:
       - name: Autobuild
         if: ${{ matrix.language != 'csharp' }}
         uses: github/codeql-action/autobuild@f443b600d91635bebf5b0d9ebc620189c0d6fba5 # v4.30.8
+        
+        # ℹ️ Command-line programs to run using the OS shell.
+        # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
+        
+        #   If the Autobuild fails above, remove it and uncomment the following three lines.
+        #   modify them (or add more) to build your code if your project, please refer to the EXAMPLE below for guidance.
 
-      # ℹ️ Command-line programs to run using the OS shell.
-      # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
-
-      #   If the Autobuild fails above, remove it and uncomment the following three lines.
-      #   modify them (or add more) to build your code if your project, please refer to the EXAMPLE below for guidance.
-          
       - name: Build C# Application
         if: ${{ matrix.language == 'csharp' }}
         run: |
-          dotnet build Distroless.sln -c Release
+          dotnet build Distroless.sln -c Release /p:MvcBuildViews=true /p:UseSharedCompilation=false /p:EmitCompilerGeneratedFiles=true
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@f443b600d91635bebf5b0d9ebc620189c0d6fba5 # v4.30.8


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated CI workflow to route builds by language, separating C# into its own build path.
  * Automated builds now run for non-C# languages; C# builds run via a dedicated C# build step.
  * Preserved and streamlined code analysis step while clarifying build guidance in workflow comments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->