### PR TITLE
docs: add Cursor Cloud development environment instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,3 +35,13 @@
 - Be mindful that `DOTNET_` env vars can influence host defaults.
 - Pin container images by major tag (e.g., `ghcr.io/...:1`) instead of `latest`.
 
+## Cursor Cloud specific instructions
+
+- **Solution file:** use `Distroless.slnx` (there is no `Distroless.sln` on disk).
+- **SDK:** .NET **10** (`net10.0`). Cloud VMs may need the SDK installed under `/usr/share/dotnet` (see CI: `10.0.x`).
+- **Docker:** required with **buildx** for `dotnet test`. On nested VMs, Docker may need `fuse-overlayfs`, `iptables-legacy`, and membership in the `docker` group (or readable `/var/run/docker.sock`).
+- **Before full test runs:** build the healthcheck image once: `docker build -f src/Distroless.HealthChecks/Dockerfile -t distroless-dotnet-healthchecks:test --target binary .` Tests read `HEALTHCHECK_IMAGE` (default `distroless-dotnet-healthchecks:test`).
+- **Running tests:** the project uses **Microsoft Testing Platform** (not VSTest `--filter`). Pass xUnit options after `--`, e.g. `dotnet test test/Distroless.HealthChecks.Test/Distroless.HealthChecks.Test.csproj -c Release -- --filter-query "/Distroless.HealthChecks.Test/.../RuntimeDeps10ContainerTest/Container_is_healthy"`. List tests: `test/Distroless.HealthChecks.Test/bin/Release/net10.0/Distroless.HealthChecks.Test -list full`.
+- **Node/pnpm:** optional for changesets/licenses. Pin Node with `.node-version` (`24.16.0`) and `pnpm install --frozen-lockfile` at the repo root.
+- **No long-running app server:** the shipped artifact is a one-shot healthcheck binary used inside container `HEALTHCHECK` definitions; integration tests are the practical end-to-end proof.
+


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a **Cursor Cloud specific instructions** section to `AGENTS.md` so future cloud agents can set up and run this repo without rediscovering:

- `Distroless.slnx` as the solution entry point
- .NET 10 + Docker/buildx prerequisites
- One-time healthcheck image build and `HEALTHCHECK_IMAGE`
- Microsoft Testing Platform filter syntax (`--filter-query` after `--`)

## Test plan

- [x] Local cloud VM setup: `dotnet build`, Docker image build, filtered integration tests passed (6/6 `RuntimeDeps10ContainerTest.Container_is_healthy`).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e54363d1-7d61-41f3-833c-f02d54e883eb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e54363d1-7d61-41f3-833c-f02d54e883eb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

