### PR TITLE
Reduce CodeQL merge blocking on stale PRs

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -15,7 +15,8 @@ permissions:
   contents: none
 
 jobs:
-  qodana:
+  qodana-pr:
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     environment: Dev
     timeout-minutes: 10
@@ -38,13 +39,54 @@ jobs:
             10.0.x
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
-          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0  # a full history is required for pull request analysis
           persist-credentials: 'false'
       - name: 'Qodana Scan'
         uses: JetBrains/qodana-action@4861e015da555e86a72b862892aba6c2b93e6891 # v2026.1.3
         with:
-          pr-mode: ${{ github.event_name == 'pull_request' }}
+          pr-mode: true
+          args: --configuration=Release,--no-statistics=true,--linter=qodana-dotnet,--within-docker,false
+          upload-result: true
+        env:
+          QODANA_TOKEN: ${{ secrets.QODANA_TOKEN }}
+          QODANA_ENDPOINT: 'https://qodana.cloud'
+      - name: Upload SARIF to GitHub
+        uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
+        if: ${{ !cancelled() }}
+        with:
+          sarif_file: ${{ runner.temp }}/qodana/results/qodana.sarif.json
+          category: 'qodana'
+
+  qodana:
+    if: github.event_name != 'pull_request'
+    runs-on: ubuntu-latest
+    environment: Dev
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      checks: write
+      security-events: write
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          disable-sudo: true
+          egress-policy: audit
+      - name: Setup Dotnet
+        id: dotnet-setup
+        uses: actions/setup-dotnet@9a946fdbd5fb07b82b2f5a4466058b876ab72bb2 # v5.3.0
+        with:
+          dotnet-version: |
+            10.0.x
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 0
+          persist-credentials: 'false'
+      - name: 'Qodana Scan'
+        uses: JetBrains/qodana-action@4861e015da555e86a72b862892aba6c2b93e6891 # v2026.1.3
+        with:
+          pr-mode: false
           args: --configuration=Release,--no-statistics=true,--linter=qodana-dotnet,--within-docker,false
           upload-result: true
         env:

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - main
       - beta
+  merge_group:
   push:
     branches: # Specify your branches here
       - main # The 'main' branch
@@ -37,13 +38,13 @@ jobs:
             10.0.x
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
-          ref: ${{ github.event.pull_request.head.sha }}  # to check out the actual pull request commit, not the merge commit
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
           fetch-depth: 0  # a full history is required for pull request analysis
           persist-credentials: 'false'
       - name: 'Qodana Scan'
         uses: JetBrains/qodana-action@4861e015da555e86a72b862892aba6c2b93e6891 # v2026.1.3
         with:
-          pr-mode: ${{ github.event.pull_request != null }}
+          pr-mode: ${{ github.event_name == 'pull_request' }}
           args: --configuration=Release,--no-statistics=true,--linter=qodana-dotnet,--within-docker,false
           upload-result: true
         env:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -17,6 +17,7 @@ on:
   pull_request:
     # The branches below must be a subset of the branches above
     branches: [ "main", "beta" ]
+  merge_group:
   schedule:
     - cron: "0 0 * * 1"
 

--- a/renovate.json5
+++ b/renovate.json5
@@ -15,9 +15,6 @@
     ':pinDependencies',
     'security:minimumReleaseAgeNpm',
   ],
-  // Rebase as soon as main moves ahead so CodeQL/Qodana scan the up-to-date head
-  // instead of leaving PRs blocked on stale test-merge commits.
-  rebaseWhen: 'behind-base-branch',
   baseBranchPatterns: [
     '$default',
     '/^beta$/',

--- a/renovate.json5
+++ b/renovate.json5
@@ -15,6 +15,9 @@
     ':pinDependencies',
     'security:minimumReleaseAgeNpm',
   ],
+  // Rebase as soon as main moves ahead so CodeQL/Qodana scan the up-to-date head
+  // instead of leaving PRs blocked on stale test-merge commits.
+  rebaseWhen: 'behind-base-branch',
   baseBranchPatterns: [
     '$default',
     '/^beta$/',


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

PRs can get stuck with *"Code scanning is waiting for results from CodeQL"* when branch protection requires code scanning and branches to be up to date with `main`. This adds `merge_group` triggers so CodeQL and Qodana run if a merge queue is enabled later.

## Changes

- **CodeQL workflow**: add `merge_group` trigger.
- **Qodana workflow**: add `merge_group` trigger and split into two jobs:
  - `qodana-pr` (`pull_request`) — keeps `pull-requests: write` for PR annotations.
  - `qodana` (`merge_group`, `push`, `workflow_dispatch`) — minimum permissions only.

Renovate was left unchanged; `:rebaseStalePrs` already handles rebasing stale PRs.

## Note on the blocking issue

For currently blocked PRs, click **Update branch** (or rebase onto `main`) to retrigger CodeQL/Qodana. Relaxing `strict_required_status_checks_policy` in the `main` ruleset would reduce this further but requires a repo admin change.

## Test plan

- [x] CI runs CodeQL and Qodana on this PR
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bf626aae-f5d7-4fab-bfd8-76716731befb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bf626aae-f5d7-4fab-bfd8-76716731befb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Chores
* Code quality analysis (Qodana and CodeQL) now runs on merge group events in addition to pull requests and pushes.
* Optimized Qodana workflow with separate job execution strategies for different event types to improve analysis efficiency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->